### PR TITLE
feat: add non-interactive CLI workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,25 @@ chmod +x ./libgen-downloader-linux-*
   	$ libgen-downloader <input>
 
   Options
-  	-s, --search <query>      search for a book
-  	-b, --bulk <MD5LIST.txt>  start the app in bulk downloading mode
-  	-u, --url <MD5>           get the download URL
-  	-d, --download <MD5>      download the file
+  	-s, --search <query>      search for a book (non-interactive output)
+  	-b, --bulk <MD5LIST.txt>  download all MD5 entries from a file
+  	-u, --url <MD5>           get the direct download URL
+  	-d, --download <MD5>      download a single file by MD5
+  	-e, --extension <ext>     filter search by extension (e.g. epub,pdf)
+  	-o, --output <dir>        output directory for downloaded files
+  	-p, --page <number>       search page number (default: 1)
+  	-l, --limit <number>      search page size (default: 25)
+  	-j, --json                output command result as JSON
+  	-q, --quiet               reduce download logs
   	-h, --help                display help
 
   Examples
   	$ libgen-downloader    (start the app in interactive mode witout flags)
-  	$ libgen-downloader -s "The Art of War"
-  	$ libgen-downloader -b ./MD5_LIST_1695686580524.txt
-  	$ libgen-downloader -u 1234567890abcdef1234567890abcdef
-  	$ libgen-downloader -d 1234567890abcdef1234567890abcdef
+  	$ libgen-downloader -s "The Art of War" -e epub
+  	$ libgen-downloader -s "Imagined Communities" -e epub -j
+  	$ libgen-downloader -b ./MD5_LIST_1695686580524.txt -o ./downloads
+  	$ libgen-downloader -u 1234567890abcdef1234567890abcdef -j
+  	$ libgen-downloader -d 1234567890abcdef1234567890abcdef -o ./downloads
 
   ```
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![npm version](https://badge.fury.io/js/libgen-downloader.svg)](https://badge.fury.io/js/libgen-downloader)
 
 
-`libgen-downloader` is a command-line tool for searching and downloading ebooks from **LibGen**. Built with `Node.js`, `TypeScript`, `React`, `Ink`, and `Zustand`, it works by visiting LibGen’s web pages, parsing the HTML, and displaying results. Since it relies on LibGen’s servers, you may occasionally encounter connection errors when searching, downloading, or loading more pages.
+`libgen-downloader` is a command-line tool for searching and downloading ebooks from **LibGen**. It supports both an interactive terminal UI and a headless CLI mode for automation. Built with `Node.js`, `TypeScript`, `React`, `Ink`, and `Zustand`, it works by visiting LibGen mirror pages, parsing the HTML, and returning results or downloads directly in the terminal.
+
+The current CLI is designed to work well with AI agents and terminal automation tools such as `Claude Code`, `Cowork`, `Codex`, and similar agentic systems. In headless mode it can search, resolve direct download URLs, download single files, run bulk downloads, and emit structured JSON output for downstream tooling.
 
 ## Important Update
 After the original `libgen` mirrors are blocked and not available anymore (see their status from here https://open-slum.org/), `libgen-downloader` now uses the `libgen+` mirrors as its primary source. You can see the new available mirrors from [configuration](https://github.com/obsfx/libgen-downloader/blob/configuration/config.v3.json).
@@ -41,10 +43,13 @@ chmod +x ./libgen-downloader-linux-*
 
 ## Features
 
-- Interactive user interface.
-- Non app blocking direct downloading.
-- Bulk downloading.
-- Alternative download options.
+- Interactive terminal UI when launched without flags.
+- Headless CLI workflows for AI agents and terminal automation.
+- Structured JSON output for machine-readable search and download operations.
+- Direct URL resolution for handing downloads off to other tools.
+- Single-file and bulk downloads by MD5.
+- Extension filtering for search results.
+- Quiet mode for lower-noise automation runs.
 - Command line parameters;
   ```
   Usage
@@ -73,9 +78,36 @@ chmod +x ./libgen-downloader-linux-*
 
   ```
 
+## Agent / Automation Usage
+
+For `Claude Code`, `Cowork`, `Codex`, and other agentic systems, prefer the flag-driven CLI instead of the interactive UI. The `-j, --json` flag returns structured output that is easier for tools and agents to parse reliably.
+
+```bash
+# Search for EPUB matches and return JSON
+libgen-downloader -s "The Art of War" -e epub -j
+
+# Resolve a direct download URL for an MD5
+libgen-downloader -u 1234567890abcdef1234567890abcdef -j
+
+# Download a single file quietly into a target directory
+libgen-downloader -d 1234567890abcdef1234567890abcdef -o ./downloads -q
+
+# Download multiple MD5 entries from a file and return a JSON summary
+libgen-downloader -b ./MD5_LIST.txt -o ./downloads -j
+```
+
 
 
 ## Changelogs
+
+v3.3.1
+
+- Added a headless CLI flow for agent-driven use cases alongside the interactive terminal UI.
+- Added non-interactive commands for search, direct URL resolution, single downloads, and bulk downloads.
+- Added structured JSON output for automation and AI agent integrations.
+- Added `--quiet` and output directory support to make unattended runs easier to manage.
+
+---
 
 v3.0.0
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "homepage": "https://github.com/obsfx/libgen-downloader",
   "scripts": {
     "start": "bun run src/index.ts",
-    "build": "bun build src/index.ts --outdir ./build --target node && echo '#!/usr/bin/env node' | cat - ./build/index.js > ./build/temp && mv ./build/temp ./build/index.js",
+    "build": "bun build src/index.ts --outdir ./build --target node && echo '#!/usr/bin/env node' | cat - ./build/index.js > ./build/temp && mv ./build/temp ./build/index.js && chmod +x ./build/index.js",
     "compile": "bun run clean && bun run compile:linux-x64 && bun run compile:linux-arm64 && bun run compile:macos-x64 && bun run compile:macos-arm64 && bun run compile:windows-x64",
     "compile:linux-x64": "bun build src/index.ts --compile --target=bun-linux-x64 --outfile ./standalone-executables/libgen-downloader-linux-x64",
     "compile:linux-arm64": "bun build src/index.ts --compile --target=bun-linux-arm64 --outfile ./standalone-executables/libgen-downloader-linux-arm64",

--- a/src/api/data/download.ts
+++ b/src/api/data/download.ts
@@ -1,18 +1,22 @@
 import contentDisposition from "content-disposition";
 // eslint-disable-next-line unicorn/prefer-node-protocol
 import fs from "fs";
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import path from "path";
 import { DownloadResult } from "../models/download-result";
 
 interface downloadFileArguments {
   downloadStream: Response;
   onStart: (filename: string, total: number) => void;
   onData: (filename: string, chunk: Buffer, total: number) => void;
+  outputDirectory?: string;
 }
 
 export const downloadFile = async ({
   downloadStream,
   onStart,
   onData,
+  outputDirectory = ".",
 }: downloadFileArguments): Promise<DownloadResult> => {
   const MAX_FILE_NAME_LENGTH = 128;
 
@@ -26,7 +30,8 @@ export const downloadFile = async ({
   const slicedFileName = fullFileName.slice(
     Math.max(fullFileName.length - MAX_FILE_NAME_LENGTH, 0)
   );
-  const path = `./${slicedFileName}`;
+  await fs.promises.mkdir(outputDirectory, { recursive: true });
+  const filePath = path.join(outputDirectory, slicedFileName);
 
   const total = Number(downloadStream.headers.get("content-length") || 0);
   const filename = parsedContentDisposition.parameters.filename;
@@ -37,7 +42,7 @@ export const downloadFile = async ({
 
   onStart(filename, total);
 
-  const file = fs.createWriteStream(path);
+  const file = fs.createWriteStream(filePath);
   const reader = downloadStream.body.getReader();
 
   try {
@@ -58,7 +63,7 @@ export const downloadFile = async ({
     });
 
     const downloadResult: DownloadResult = {
-      path,
+      path: filePath,
       filename,
       total,
     };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -6,18 +6,25 @@ export const cli = meow(
 	  $ libgen-downloader <input>
 
 	Options
-    -s, --search <query>      search for a book
-    -b, --bulk <MD5LIST.txt>  start the app in bulk downloading mode
-    -u, --url <MD5>           get the download URL
-    -d, --download <MD5>      download the file
+    -s, --search <query>      search for a book (non-interactive output)
+    -b, --bulk <MD5LIST.txt>  download all MD5 entries from a file
+    -u, --url <MD5>           get the direct download URL
+    -d, --download <MD5>      download a single file by MD5
+    -e, --extension <ext>     filter search by extension (e.g. epub,pdf)
+    -o, --output <dir>        output directory for downloaded files
+    -p, --page <number>       search page number (default: 1)
+    -l, --limit <number>      search page size (default: 25)
+    -j, --json                output command result as JSON
+    -q, --quiet               reduce download logs
     -h, --help                display help
 
 	Examples
     $ libgen-downloader    (start the app in interactive mode witout flags)
-    $ libgen-downloader -s "The Art of War"
-    $ libgen-downloader -b ./MD5_LIST_1695686580524.txt
-    $ libgen-downloader -u 1234567890abcdef1234567890abcdef
-    $ libgen-downloader -d 1234567890abcdef1234567890abcdef
+    $ libgen-downloader -s "The Art of War" -e epub
+    $ libgen-downloader -s "Imagined Communities" -e epub -j
+    $ libgen-downloader -b ./MD5_LIST_1695686580524.txt -o ./downloads
+    $ libgen-downloader -u 1234567890abcdef1234567890abcdef -j
+    $ libgen-downloader -d 1234567890abcdef1234567890abcdef -o ./downloads
 `,
   {
     importMeta: import.meta,
@@ -37,6 +44,30 @@ export const cli = meow(
       download: {
         type: "string",
         shortFlag: "d",
+      },
+      extension: {
+        type: "string",
+        shortFlag: "e",
+      },
+      output: {
+        type: "string",
+        shortFlag: "o",
+      },
+      page: {
+        type: "number",
+        shortFlag: "p",
+      },
+      limit: {
+        type: "number",
+        shortFlag: "l",
+      },
+      json: {
+        type: "boolean",
+        shortFlag: "j",
+      },
+      quiet: {
+        type: "boolean",
+        shortFlag: "q",
       },
       help: {
         type: "boolean",

--- a/src/cli/non-interactive.ts
+++ b/src/cli/non-interactive.ts
@@ -1,0 +1,419 @@
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import fs from "fs";
+// eslint-disable-next-line unicorn/prefer-node-protocol
+import path from "path";
+import { getAdapter } from "../api/adapters";
+import type { Adapter } from "../api/adapters/adapter";
+import { fetchConfig, findMirror } from "../api/data/config";
+import { downloadFile } from "../api/data/download";
+import { getDocument } from "../api/data/document";
+import type { Entry } from "../api/models/entry";
+import { SEARCH_PAGE_SIZE } from "../settings";
+
+interface CLIOptions {
+  extension?: string;
+  json: boolean;
+  page: number;
+  limit: number;
+  outputDirectory: string;
+  quiet: boolean;
+}
+
+interface SearchResultEntry {
+  md5: string;
+  title: string;
+  authors: string;
+  publisher: string;
+  year: string;
+  pages: string;
+  language: string;
+  size: string;
+  extension: string;
+  mirror: string;
+}
+
+interface DownloadItemResult {
+  md5: string;
+  status: "downloaded" | "failed";
+  path?: string;
+  error?: string;
+}
+
+interface RuntimeContext {
+  adapter: Adapter;
+  mirrorSource: string;
+}
+
+const MD5_REGEX = /^[\da-f]{32}$/i;
+
+function normalizeExtensionFilter(extensionValue?: string): Set<string> | undefined {
+  if (!extensionValue) {
+    return;
+  }
+
+  const extensions = extensionValue
+    .split(",")
+    .map((item) => item.trim().toLowerCase().replace(/^\./, ""))
+    .filter(Boolean);
+
+  if (extensions.length === 0) {
+    return;
+  }
+
+  return new Set(extensions);
+}
+
+function normalizeEntryExtension(extension: string): string {
+  return extension.trim().toLowerCase().replace(/^\./, "");
+}
+
+function extractMD5FromMirrorURL(adapter: Adapter, mirror: string): string {
+  const mirrorURL = adapter.getPageURL(mirror);
+  const url = new URL(mirrorURL);
+  return url.searchParams.get("md5") || "";
+}
+
+function mapEntry(adapter: Adapter, entry: Entry): SearchResultEntry {
+  return {
+    md5: extractMD5FromMirrorURL(adapter, entry.mirror),
+    title: entry.title,
+    authors: entry.authors,
+    publisher: entry.publisher,
+    year: entry.year,
+    pages: entry.pages,
+    language: entry.language,
+    size: entry.size,
+    extension: entry.extension,
+    mirror: adapter.getPageURL(entry.mirror),
+  };
+}
+
+function parsePositiveInteger(
+  value: unknown,
+  defaultValue: number,
+  flagLabel: string
+): number {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    return defaultValue;
+  }
+
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${flagLabel} must be a positive integer`);
+  }
+
+  return value;
+}
+
+function parseOutputDirectory(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return process.cwd();
+  }
+
+  return path.resolve(value);
+}
+
+function getCLIOptions(flags: Record<string, unknown>): CLIOptions {
+  let extension: string | undefined;
+  if (typeof flags.extension === "string") {
+    extension = flags.extension;
+  }
+
+  return {
+    extension,
+    json: flags.json === true,
+    page: parsePositiveInteger(flags.page, 1, "--page"),
+    limit: parsePositiveInteger(flags.limit, SEARCH_PAGE_SIZE, "--limit"),
+    outputDirectory: parseOutputDirectory(flags.output),
+    quiet: flags.quiet === true,
+  };
+}
+
+async function getRuntimeContext(): Promise<RuntimeContext> {
+  const config = await fetchConfig();
+  const mirror = await findMirror(config.mirrors, () => {});
+
+  if (!mirror) {
+    throw new Error("Couldn't find a working mirror");
+  }
+
+  return {
+    adapter: getAdapter(mirror.src, mirror.type),
+    mirrorSource: mirror.src,
+  };
+}
+
+function printSearchResults(results: SearchResultEntry[]) {
+  if (results.length === 0) {
+    console.log("No results found.");
+    return;
+  }
+
+  for (const [index, result] of results.entries()) {
+    console.log(`[${index + 1}] ${result.title}`);
+    console.log(`    md5: ${result.md5}`);
+    console.log(`    authors: ${result.authors}`);
+    console.log(`    language: ${result.language} | extension: ${result.extension} | size: ${result.size}`);
+    console.log(`    year: ${result.year} | publisher: ${result.publisher}`);
+    console.log(`    mirror: ${result.mirror}`);
+  }
+}
+
+function assertValidMD5(md5: string) {
+  if (!MD5_REGEX.test(md5)) {
+    throw new Error(`Invalid MD5 value: ${md5}`);
+  }
+}
+
+async function resolveDownloadURL(context: RuntimeContext, md5: string): Promise<string> {
+  const detailPageURL = context.adapter.getDetailPageURL(md5);
+  const detailPageResult = await getDocument(detailPageURL);
+
+  const connectionError = context.adapter.detectConnectionError(detailPageResult.document);
+  if (connectionError) {
+    throw new Error(connectionError);
+  }
+
+  const downloadURL = context.adapter.getMainDownloadURLFromDocument(detailPageResult.document);
+  if (!downloadURL) {
+    throw new Error(`Couldn't find download URL for ${md5}`);
+  }
+
+  return downloadURL;
+}
+
+async function performDownload(
+  context: RuntimeContext,
+  md5: string,
+  options: CLIOptions,
+  index: number,
+  total: number
+): Promise<DownloadItemResult> {
+  const logPrefix = `[${index + 1}/${total}]`;
+  if (!options.quiet) {
+    console.log(`${logPrefix} Resolving download URL for ${md5}...`);
+  }
+
+  try {
+    const downloadURL = await resolveDownloadURL(context, md5);
+    const downloadStream = await fetch(downloadURL);
+    if (!downloadStream.ok) {
+      throw new Error(`Download request failed with status ${downloadStream.status}`);
+    }
+
+    let downloaded = 0;
+    let latestLoggedPercent = -1;
+
+    const result = await downloadFile({
+      downloadStream,
+      outputDirectory: options.outputDirectory,
+      onStart: (filename, totalSize) => {
+        if (!options.quiet) {
+          console.log(`${logPrefix} Downloading ${filename} (${totalSize} bytes)`);
+        }
+      },
+      onData: (_filename, chunk, totalSize) => {
+        if (options.quiet) {
+          return;
+        }
+
+        downloaded += chunk.length;
+        if (totalSize <= 0) {
+          return;
+        }
+
+        const percent = Math.floor((downloaded / totalSize) * 100);
+        if (percent < latestLoggedPercent + 10 && percent !== 100) {
+          return;
+        }
+
+        latestLoggedPercent = percent;
+        console.log(`${logPrefix} ${percent}%`);
+      },
+    });
+
+    if (!options.quiet) {
+      console.log(`${logPrefix} Saved to ${result.path}`);
+    }
+
+    return {
+      md5,
+      status: "downloaded",
+      path: result.path,
+    };
+  } catch (error: unknown) {
+    const message = (error as Error).message;
+    console.error(`${logPrefix} Failed ${md5}: ${message}`);
+    return {
+      md5,
+      status: "failed",
+      error: message,
+    };
+  }
+}
+
+export async function runSearchCommand(
+  query: string,
+  flags: Record<string, unknown>
+): Promise<void> {
+  const options = getCLIOptions(flags);
+  const context = await getRuntimeContext();
+
+  const searchURL = context.adapter.getSearchURL(query, options.page, options.limit);
+  const searchDocument = await getDocument(searchURL);
+  const connectionError = context.adapter.detectConnectionError(searchDocument.document);
+  if (connectionError) {
+    throw new Error(connectionError);
+  }
+
+  const entries = context.adapter.parseEntries(searchDocument.document);
+  if (!entries) {
+    throw new Error(`Couldn't parse the search page for "${query}"`);
+  }
+
+  const extensionFilter = normalizeExtensionFilter(options.extension);
+  const filteredEntries: Entry[] = [];
+  for (const entry of entries) {
+    if (!extensionFilter) {
+      filteredEntries.push(entry);
+      continue;
+    }
+
+    const entryExtension = normalizeEntryExtension(entry.extension);
+    if (extensionFilter.has(entryExtension)) {
+      filteredEntries.push(entry);
+    }
+  }
+
+  const results = filteredEntries.map((entry) => mapEntry(context.adapter, entry));
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          query,
+          page: options.page,
+          limit: options.limit,
+          extensionFilter: options.extension,
+          mirror: context.mirrorSource,
+          count: results.length,
+          results,
+        },
+        undefined,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`Active mirror: ${context.mirrorSource}`);
+  console.log(`Query: ${query}`);
+  console.log(`Page: ${options.page} | Limit: ${options.limit}`);
+  if (options.extension) {
+    console.log(`Extension filter: ${options.extension}`);
+  }
+  console.log("");
+  printSearchResults(results);
+}
+
+export async function runURLCommand(md5: string, flags: Record<string, unknown>): Promise<void> {
+  const options = getCLIOptions(flags);
+  assertValidMD5(md5);
+
+  const context = await getRuntimeContext();
+  const downloadURL = await resolveDownloadURL(context, md5);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          md5,
+          mirror: context.mirrorSource,
+          downloadURL,
+        },
+        undefined,
+        2
+      )
+    );
+    return;
+  }
+
+  console.log(`Active mirror: ${context.mirrorSource}`);
+  console.log("Here is the direct download link:");
+  console.log(downloadURL);
+}
+
+function sanitizeMD5List(values: string[]): string[] {
+  const uniqueValues = new Set<string>();
+
+  for (const value of values) {
+    const md5 = value.trim();
+    if (md5.length === 0) {
+      continue;
+    }
+
+    if (!MD5_REGEX.test(md5)) {
+      console.error(`Skipping invalid MD5: ${md5}`);
+      continue;
+    }
+
+    uniqueValues.add(md5);
+  }
+
+  return [...uniqueValues];
+}
+
+export async function readMD5List(filePath: string): Promise<string[]> {
+  const content = await fs.promises.readFile(filePath, "utf8");
+  return sanitizeMD5List(content.split(/\r?\n/u));
+}
+
+export async function runDownloadCommand(
+  md5List: string[],
+  flags: Record<string, unknown>
+): Promise<void> {
+  const options = getCLIOptions(flags);
+  const normalizedMD5List = sanitizeMD5List(md5List);
+
+  if (normalizedMD5List.length === 0) {
+    throw new Error("No valid MD5 values provided");
+  }
+
+  const context = await getRuntimeContext();
+  if (!options.quiet) {
+    console.log(`Active mirror: ${context.mirrorSource}`);
+    console.log(`Output directory: ${options.outputDirectory}`);
+  }
+
+  const results: DownloadItemResult[] = [];
+  for (const [index, md5] of normalizedMD5List.entries()) {
+    results.push(await performDownload(context, md5, options, index, normalizedMD5List.length));
+  }
+
+  const failedItems = results.filter((result) => result.status === "failed");
+  const downloadedItems = results.filter((result) => result.status === "downloaded");
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          total: results.length,
+          downloaded: downloadedItems.length,
+          failed: failedItems.length,
+          results,
+        },
+        undefined,
+        2
+      )
+    );
+  } else {
+    console.log("");
+    console.log("Download summary");
+    console.log(`Total: ${results.length}`);
+    console.log(`Downloaded: ${downloadedItems.length}`);
+    console.log(`Failed: ${failedItems.length}`);
+  }
+
+  if (failedItems.length > 0) {
+    process.exitCode = 1;
+  }
+}

--- a/src/cli/operate.ts
+++ b/src/cli/operate.ts
@@ -1,10 +1,5 @@
-// eslint-disable-next-line unicorn/prefer-node-protocol
-import fs from "fs";
-import { getDocument } from "../api/data/document";
+import { readMD5List, runDownloadCommand, runSearchCommand, runURLCommand } from "./non-interactive";
 import renderTUI from "../tui/index";
-import { LAYOUT_KEY } from "../tui/layouts/keys";
-import { useBoundStore } from "../tui/store/index";
-import { attempt } from "../utilities";
 
 export const operate = async (flags: Record<string, unknown>) => {
   if (flags.search) {
@@ -14,75 +9,27 @@ export const operate = async (flags: Record<string, unknown>) => {
       return;
     }
 
-    const store = useBoundStore.getState();
-    await store.fetchConfig();
-    store.setSearchValue(query);
-    renderTUI({
-      startInCLIMode: false,
-      doNotFetchConfigInitially: true,
-    });
-    store.handleSearchSubmit();
+    await runSearchCommand(query, flags);
     return;
   }
 
   if (flags.bulk) {
     const filePath = flags.bulk as string;
-    const data = await fs.promises.readFile(filePath, "utf8");
-    const md5List = data.split("\n").filter((line) => line.trim());
-    const store = useBoundStore.getState();
-    await store.fetchConfig();
-    renderTUI({
-      startInCLIMode: true,
-      doNotFetchConfigInitially: true,
-      initialLayout: LAYOUT_KEY.BULK_DOWNLOAD_LAYOUT,
-    });
-    store.startBulkDownloadInCLI(md5List);
+    const md5List = await readMD5List(filePath);
+    await runDownloadCommand(md5List, flags);
     return;
   }
 
   if (flags.url) {
     const md5 = flags.url as string;
-
-    console.log("Fetching config...");
-    await useBoundStore.getState().fetchConfig();
-    const store = useBoundStore.getState();
-
-    console.log("Finding download url...");
-    const detailPageUrl = store.mirrorAdapter?.getDetailPageURL(md5);
-    if (!detailPageUrl) {
-      console.log("Failed to get detail page URL");
-      return;
-    }
-
-    const detailPageResult = await attempt(() => getDocument(detailPageUrl));
-    if (!detailPageResult) {
-      console.log("Failed to get detail page document");
-      return;
-    }
-
-    const downloadUrl = store.mirrorAdapter?.getMainDownloadURLFromDocument(detailPageResult.document);
-    if (!downloadUrl) {
-      console.log("Failed to find download url");
-      return;
-    }
-
-    console.log("Here is the direct download link:");
-    console.log(downloadUrl);
+    await runURLCommand(md5, flags);
 
     return;
   }
 
   if (flags.download) {
     const md5 = flags.download as string;
-    const md5List = [md5];
-    const store = useBoundStore.getState();
-    await store.fetchConfig();
-    renderTUI({
-      startInCLIMode: true,
-      doNotFetchConfigInitially: true,
-      initialLayout: LAYOUT_KEY.BULK_DOWNLOAD_LAYOUT,
-    });
-    store.startBulkDownloadInCLI(md5List);
+    await runDownloadCommand([md5], flags);
     return;
   }
 


### PR DESCRIPTION
## Summary
- add non-interactive CLI flows for search, URL lookup, single download, and bulk download
- support extension filtering, JSON output, paging, limits, quiet mode, and configurable download output directory
- update download path handling, docs, and build output permissions

## Verification
- bun run build
- bun run lint